### PR TITLE
Use DateTimeInterface for parameters

### DIFF
--- a/src/Data/Generator/Parameter.php
+++ b/src/Data/Generator/Parameter.php
@@ -33,6 +33,8 @@ class Parameter
         $type = $this->type;
         if (! Utils::isBuiltInType($type)) {
             $type = NameHelper::safeClassName($type);
+        } else if ($type === 'DateTime') {
+            $type = '\DateTimeInterface';
         }
         $nullString = str_contains($type, '|') ? 'null|' : '?';
 

--- a/src/Generators/DtoGenerator.php
+++ b/src/Generators/DtoGenerator.php
@@ -97,6 +97,11 @@ class DtoGenerator extends BaseDtoGenerator
             $safeType = Utils::isBuiltinType($additionalProperties->type)
                 ? $additionalProperties->type
                 : NameHelper::safeClassName($additionalProperties->type);
+
+            if ($safeType === 'DateTime') {
+                $safeType = '\DateTimeInterface';
+            }
+
             $classType->addProperty('additionalProperties')
                 ->setPublic()
                 ->addComment("@var {$safeType}[]")

--- a/src/Helpers/MethodGeneratorHelper.php
+++ b/src/Helpers/MethodGeneratorHelper.php
@@ -59,7 +59,7 @@ class MethodGeneratorHelper
 
         $type = $parameter->type;
         if ($type === 'DateTime') {
-            $type = '\DateTime';
+            $type = '\DateTimeInterface';
         } elseif (! Utils::isBuiltInType($type)) {
             if ($namespace === null) {
                 throw new InvalidArgumentException('$namespace must be passed if the type is not a built-in.');

--- a/src/Traits/HasArrayableAttributes.php
+++ b/src/Traits/HasArrayableAttributes.php
@@ -6,6 +6,7 @@ namespace Crescat\SaloonSdkGenerator\Traits;
 
 use Crescat\SaloonSdkGenerator\Exceptions\InvalidAttributeTypeException;
 use DateTime;
+use DateTimeInterface;
 use ReflectionClass;
 
 trait HasArrayableAttributes
@@ -59,7 +60,7 @@ trait HasArrayableAttributes
     {
         if (is_null($value)) {
             return null;
-        } elseif ($value instanceof DateTime) {
+        } elseif ($value instanceof DateTimeInterface) {
             return $value->format(DateTime::RFC3339);
         } elseif (is_string($type)) {
             if (class_exists($type)) {


### PR DESCRIPTION
We should use `\DateTimeInterface` for parameters so that we can accept `\DateTime` or `\DateTimeImmutable`.

Additionally, use the root namespace on phpdoc comments so that tools like Psalm don't think there's a class in the current namespace.

Should solve https://github.com/jlevers/selling-partner-api/issues/718