### PR TITLE
Include the body content type in Schema

### DIFF
--- a/src/Data/Generator/Schema.php
+++ b/src/Data/Generator/Schema.php
@@ -31,6 +31,7 @@ class Schema extends Parameter
         public ?Schema $items = null,
         public ?array $properties = [],
         public ?array $required = null,
+        public ?string $bodyContentType = null,
     ) {
         if (is_null($name)) {
             if ($this->parent->type === SimpleType::ARRAY->value) {

--- a/src/Parsers/OpenApiParser.php
+++ b/src/Parsers/OpenApiParser.php
@@ -314,6 +314,7 @@ class OpenApiParser implements Parser
 
         $parsedSchema = $this->parseSchema($mediaType->schema);
 
+        $parsedSchema->bodyContentType = $contentType;
         return $parsedSchema;
     }
 


### PR DESCRIPTION
We only want to add the `HasJsonBody` trait to requests expecting an `application/json` body, but this information is not currently available

This commit adds the data into the schema object so we can retrieve it when generating request objects.