### PR TITLE
Check for circular references when parsing schemas

### DIFF
--- a/src/Parsers/OpenApiParser.php
+++ b/src/Parsers/OpenApiParser.php
@@ -115,6 +115,14 @@ class OpenApiParser implements Parser
     {
         $parsedSchemas = [];
         foreach ($schemas as $name => $schema) {
+            $_parent = $parent;
+            while ($_parent !== null) {
+                if ($_parent->rawName === $name) {
+                    continue 2;
+                }
+                $_parent = $_parent->parent;
+            }
+
             $parsed = $this->parseSchema($schema, $parent, $name);
             if ($parsed) {
                 $parsedSchemas[$name] = $parsed;


### PR DESCRIPTION
@dpash this appears to fix https://github.com/jlevers/selling-partner-api/issues/719. Just want to check that the solution seems sane to you.